### PR TITLE
Adding ossf analysis and badge

### DIFF
--- a/.github/workflows/ossf-analysis.yml
+++ b/.github/workflows/ossf-analysis.yml
@@ -1,0 +1,26 @@
+name: Scorecards supply-chain security scan
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  
+  schedule:
+    # Weekly on Saturdays.
+    - cron: '33 1 * * 6'
+  push:
+    branches: 
+      - main
+
+  workflow_dispatch:
+    
+# Declare default GITHUB_TOKEN permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    uses: devops-actions/.github/.github/workflows/rw-ossf-scorecard.yml@main
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      id-token: write
+      actions: read
+      contents: read

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 > 
 > Request issues through the issues in this new repo and I will have a look!
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/devops-actions/azure-appservice-settings/badge)](https://api.securityscorecards.dev/projects/github.com/devops-actions/azure-appservice-settings)
+
 With the Azure App Service Actions for GitHub, you can automate your workflow to deploy [Azure Web Apps](https://azure.microsoft.com/en-us/services/app-service/web/) and configure [App settings](https://docs.microsoft.com/en-us/azure/app-service/configure-common).
 
 Get started today with a [free Azure account](https://azure.com/free/open-source)!
@@ -97,7 +99,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: azure/login@v1
       with:
@@ -124,7 +126,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: azure/login@v1
       with:


### PR DESCRIPTION
This pull request includes changes to enhance the security of the project and improve the build process. The most significant changes are the addition of a new GitHub workflow for Scorecards supply-chain security scan, the inclusion of an OpenSSF Scorecard badge in the `README.md` file, and the update of the build process to run on Ubuntu instead of Windows.

Security Enhancements:

* [`.github/workflows/ossf-analysis.yml`](diffhunk://#diff-18606e57013ddf91a835f43339d2a56e619c21057c07c75cd652a69089340ea6R1-R26): Added a new GitHub workflow for Scorecards supply-chain security scan. This workflow runs weekly on Saturdays and each time there's a push to the main branch. It uses read-only permissions by default and requires write permissions for security-events and id-token to upload the results to the code-scanning dashboard.

Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R7): Added an OpenSSF Scorecard badge to provide a quick view of the project's security score.

Build Process Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R102): Updated the build process to run on Ubuntu instead of Windows. This change was made in two jobs within the `on: [push]` section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R102) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R129)