### PR TITLE
Create approve-dependabot-pr.yml

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -1,0 +1,16 @@
+name: "Approve Dependabot PR's" 
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow in the `.github/workflows/approve-dependabot-pr.yml` file. The workflow is designed to automatically approve Dependabot pull requests. 

* [`.github/workflows/approve-dependabot-pr.yml`](diffhunk://#diff-e6f85d1989f1ca060a5f603b6b16deeda1033b0bf6852dc431d482b485c99ce2R1-R16): Added a new workflow that automatically approves Dependabot pull requests. This workflow has read permissions for repository contents and write permissions for pull requests and actions. It uses the `devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main` action and the `GITHUB_TOKEN` secret for authentication.