### PR TITLE
Add GitHub Actions workflow for dependencies submission

### DIFF
--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -1,0 +1,18 @@
+name: Submit Actions Dependencies
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 1' # Weekly
+
+jobs:
+  submit-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to read workflow files
+      id-token: write # Required for dependency submission
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jessehouwing/actions-dependency-submission@v0.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate dependency submission for actions used in the repository. The workflow is triggered on pushes to the `main` branch and runs weekly on a schedule.

**Continuous Integration improvements:**

* Added `.github/workflows/actions-dependencies.yml` to automatically submit dependencies for GitHub Actions using the `jessehouwing/actions-dependency-submission` action, triggered on push to `main` and on a weekly schedule.