### PR TITLE
Migrate to reusable workflow

### DIFF
--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -1,3 +1,4 @@
+
 name: Submit Actions Dependencies
 on:
   push:
@@ -7,12 +8,6 @@ on:
 
 jobs:
   submit-dependencies:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Required to read workflow files
-      id-token: write # Required for dependency submission
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jessehouwing/actions-dependency-submission@v0.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    uses: devops-actions/.github/.github/workflows/actions-dependencies.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/actions-dependencies.yml` workflow to use a reusable workflow from a central repository, simplifying maintenance and improving consistency.

Workflow refactoring:

* The `submit-dependencies` job now uses the reusable workflow from `devops-actions/.github/.github/workflows/actions-dependencies.yml@main`, replacing the previous inline job definition and steps.
* The workflow file is renamed and updated to support the new reusable workflow format.