### PR TITLE
Add release notes categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  categories:
+    - title: Improvements
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Dependency updates (GitHub Actions)
+      labels:
+        - github_actions
+    - title: Dependency updates (Other)
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- introduce release drafter config with split dependency categories
- match GitHub Actions standard release notes template

## Testing
- not applicable