### PR TITLE
fix: sync workflows with devops-actions/.github standards

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+﻿name: Lint GitHub Actions workflows
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  actionlint:
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Sync workflows with the devops-actions/.github shared workflow standards:

- **dependency-review.yml**: replaced standalone workflow with the standard caller pattern pointing to \devops-actions/.github\
- **actionlint.yml**: added missing caller for the shared actionlint reusable workflow
- **scorecards.yml**: removed duplicate standalone OSSF scorecard workflow (\ossf-analysis.yml\ already covers this via \w-ossf-scorecard.yml\)