### PR TITLE
chore: upgrade action runtime to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: 'Setup Node.js'
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: 'Validate build'
       run: |

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ branding:
   icon: 'webapp.svg'
   color: 'blue'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Upgrades the action runtime from `node20` to `node24`, and updates CI workflows to use Node 24 as well.