### PR TITLE
fix: restrict token permissions in workflows

### DIFF
--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
   submit-dependencies:
     uses: devops-actions/.github/.github/workflows/actions-dependencies.yml@b77cea6d7ba1cd4e001581783cc592bbb63ce46d # main
     permissions:
-      contents: write # Required to read workflow files
+      contents: write # Required for the dependency submission API
       id-token: write # Required for dependency submission
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@b77cea6d7ba1cd4e001581783cc592bbb63ce46d # main
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -13,11 +13,13 @@ on:
         default: 'dependabot/npm_and_yarn/qs-6.15.2'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+This is the `devops-actions/azure-appservice-settings` repository — a GitHub Action that sets Azure App Service settings.
+
+For project-specific coding conventions or instructions, see any `.github/copilot-instructions.md` file if present.


### PR DESCRIPTION
## Summary

Fixes OSSF TokenPermissionsID code scanning alerts:

| Alert | File | Issue | Fix |
|-------|------|-------|-----|
| #37 | \ebuild-dist.yml\ | Top-level \contents: write\ | Moved to job-level; top-level set to \contents: read\ |
| #36 | \pprove-dependabot-pr.yml\ | Job-level \ctions: write\ | Removed (not required for approving/merging PRs) |

### Notes on remaining alerts
- **#35** (\ctions-dependencies.yml\): \contents: write\ is legitimately required by the [GitHub Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission). Updated comment to clarify.
- **#7** (\ossf-analysis.yml\): \security-events: write\ is required to upload SARIF results to the code scanning dashboard. Cannot be reduced.

Also adds \AGENTS.md\ to the repo root.