### PR TITLE
fix: pin workflow action dependencies to commit hashes

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@1601bb32b0ecab29b4ecce7861b892ed5b00700a # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -19,12 +19,12 @@ jobs:
   rebuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '20'
 


### PR DESCRIPTION
## Summary

Fixes OSSF PinnedDependenciesID code scanning alerts by pinning all actions/reusable workflows to specific commit SHAs:

| Alert | File | Action | Pinned to |
|-------|------|--------|-----------|
| #38 | \ebuild-dist.yml\ | \ctions/checkout@v4\ | \11bd71901bbe5b1630ceea73d27597364c9af683\ (v4.2.2) |
| #39 | \ebuild-dist.yml\ | \ctions/setup-node@v4\ | \49933ea5288caeca8642d1e84afbd3f7d6820020\ (v4.4.0) |
| #34 | \ctionlint.yml\ | \devops-actions/.github actionlint.yml@main\ | \1601bb32b0ecab29b4ecce7861b892ed5b00700a\ |

Pinning to commit SHAs prevents supply chain attacks where a tag could be moved to point to malicious code.